### PR TITLE
Removes Internal Panics and Races

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ _testmain.go
 
 *.exe
 *.test
+
+*.DS_Store

--- a/gocron.go
+++ b/gocron.go
@@ -230,11 +230,13 @@ func (j *Job) scheduleNextRun() error {
 
 	switch j.unit {
 	case days:
+		j.shouldDo = true
 		j.mu.Lock()
 		j.nextRun = j.roundToMidnight(j.lastRun)
 		j.nextRun = j.nextRun.Add(j.atTime)
 		j.mu.Unlock()
 	case weeks:
+		j.shouldDo = true
 		j.mu.Lock()
 		j.nextRun = j.roundToMidnight(j.lastRun)
 		dayDiff := int(j.startDay)

--- a/gocron.go
+++ b/gocron.go
@@ -589,3 +589,8 @@ func Remove(j interface{}) {
 func NextRun() (job *Job, time time.Time) {
 	return defaultScheduler.NextRun()
 }
+
+// Len gets the amount of jobs in the scheduler
+func Len() int {
+	return defaultScheduler.Len()
+}

--- a/gocron.go
+++ b/gocron.go
@@ -132,6 +132,10 @@ func (j *Job) Err() error {
 
 // Do specifies the jobFunc that should be called every time the job runs
 func (j *Job) Do(jobFun interface{}, params ...interface{}) error {
+	if j.err != nil {
+		return j.err
+	}
+
 	typ := reflect.TypeOf(jobFun)
 	if typ.Kind() != reflect.Func {
 		return ErrNotAFunction

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -14,9 +14,9 @@ func taskWithParams(a int, b string) {
 	fmt.Println(a, b)
 }
 
-func assertEqualTime(t *testing.T, actual, expected time.Time) {
+func assertEqualTime(name string, t *testing.T, actual, expected time.Time) {
 	if actual != expected {
-		t.Errorf("actual different than expected want: %v -> got: %v", expected, actual)
+		t.Errorf("test name: %s actual different than expected want: %v -> got: %v", name, expected, actual)
 	}
 }
 
@@ -130,7 +130,7 @@ func TestTaskAt(t *testing.T) {
 
 	// Check first run
 	nextRun := dayJob.NextScheduledTime()
-	assertEqualTime(t, nextRun, startTime)
+	assertEqualTime("first run", t, nextRun, startTime)
 
 	sStop := s.Start()      // Start scheduler
 	<-dayJobDone            // Wait job done
@@ -139,7 +139,7 @@ func TestTaskAt(t *testing.T) {
 
 	// Check next run
 	nextRun = dayJob.NextScheduledTime()
-	assertEqualTime(t, nextRun, startNext)
+	assertEqualTime("next run", t, nextRun, startNext)
 }
 
 func TestDaily(t *testing.T) {
@@ -152,20 +152,20 @@ func TestDaily(t *testing.T) {
 	dayJob := s.Every(1).Day()
 	dayJob.scheduleNextRun()
 	exp := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, loc)
-	assertEqualTime(t, dayJob.nextRun, exp)
+	assertEqualTime("1 day", t, dayJob.nextRun, exp)
 
 	// schedule next run 2 days
 	dayJob = s.Every(2).Days()
 	dayJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+2, 0, 0, 0, 0, loc)
-	assertEqualTime(t, dayJob.nextRun, exp)
+	assertEqualTime("2 days", t, dayJob.nextRun, exp)
 
 	// Job running longer than next schedule 1day 2 hours
 	dayJob = s.Every(1).Day()
 	dayJob.lastRun = time.Date(now.Year(), now.Month(), now.Day(), now.Hour()+2, 0, 0, 0, loc)
 	dayJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, loc)
-	assertEqualTime(t, dayJob.nextRun, exp)
+	assertEqualTime("1 day 2 hours", t, dayJob.nextRun, exp)
 
 	// At() 2 hours before now
 	hour := now.Hour() - 2
@@ -178,7 +178,7 @@ func TestDaily(t *testing.T) {
 
 	dayJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+1, hour, minute, 0, 0, loc)
-	assertEqualTime(t, dayJob.nextRun, exp)
+	assertEqualTime("at 2 hours before now", t, dayJob.nextRun, exp)
 }
 
 func TestWeekdayAfterToday(t *testing.T) {
@@ -209,14 +209,14 @@ func TestWeekdayAfterToday(t *testing.T) {
 	// First run
 	weekJob.scheduleNextRun()
 	exp := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, loc)
-	assertEqualTime(t, weekJob.nextRun, exp)
+	assertEqualTime("first run", t, weekJob.nextRun, exp)
 
 	// Simulate job run 7 days before
 	weekJob.lastRun = weekJob.nextRun.AddDate(0, 0, -7)
 	// Next run
 	weekJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, loc)
-	assertEqualTime(t, weekJob.nextRun, exp)
+	assertEqualTime("next run", t, weekJob.nextRun, exp)
 }
 
 func TestWeekdayBeforeToday(t *testing.T) {
@@ -246,14 +246,14 @@ func TestWeekdayBeforeToday(t *testing.T) {
 
 	weekJob.scheduleNextRun()
 	exp := time.Date(now.Year(), now.Month(), now.Day()+6, 0, 0, 0, 0, loc)
-	assertEqualTime(t, weekJob.nextRun, exp)
+	assertEqualTime("first run", t, weekJob.nextRun, exp)
 
 	// Simulate job run 7 days before
 	weekJob.lastRun = weekJob.nextRun.AddDate(0, 0, -7)
 	// Next run
 	weekJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+6, 0, 0, 0, 0, loc)
-	assertEqualTime(t, weekJob.nextRun, exp)
+	assertEqualTime("nest run", t, weekJob.nextRun, exp)
 }
 
 func TestWeekdayAt(t *testing.T) {
@@ -309,12 +309,12 @@ func TestWeekdayAt(t *testing.T) {
 	// First run
 	weekJob.scheduleNextRun()
 	exp := time.Date(now.Year(), now.Month(), now.Day()+1, hour, minute, 0, 0, loc)
-	assertEqualTime(t, weekJob.nextRun, exp)
+	assertEqualTime("first run", t, weekJob.nextRun, exp)
 
 	// Simulate job run 7 days before
 	weekJob.lastRun = weekJob.nextRun.AddDate(0, 0, -7)
 	// Next run
 	weekJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+1, hour, minute, 0, 0, loc)
-	assertEqualTime(t, weekJob.nextRun, exp)
+	assertEqualTime("next run", t, weekJob.nextRun, exp)
 }

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -20,12 +20,16 @@ func assertEqualTime(t *testing.T, actual, expected time.Time) {
 	}
 }
 
-func TestSecond(*testing.T) {
+func TestSecond(t *testing.T) {
 	defaultScheduler.Every(1).Second().Do(task)
 	defaultScheduler.Every(1).Second().Do(taskWithParams, 1, "hello")
 	stop := defaultScheduler.Start()
 	time.Sleep(5 * time.Second)
 	close(stop)
+
+	if err := defaultScheduler.Err(); err != nil {
+		t.Error(err)
+	}
 	defaultScheduler.Clear()
 }
 
@@ -110,7 +114,10 @@ func TestTaskAt(t *testing.T) {
 
 	// Schedule every day At
 	startAt := fmt.Sprintf("%02d:%02d", now.Hour(), now.Minute()+1)
-	dayJob := s.Every(1).Day().At(startAt)
+	dayJob, err := s.Every(1).Day().At(startAt)
+	if err != nil {
+		t.Error(err)
+	}
 
 	dayJobDone := make(chan bool, 1)
 	// Job running 5 sec
@@ -164,7 +171,10 @@ func TestDaily(t *testing.T) {
 	hour := now.Hour() - 2
 	minute := now.Minute()
 	startAt := fmt.Sprintf("%02d:%02d", hour, minute)
-	dayJob = s.Every(1).Day().At(startAt)
+	dayJob, err := s.Every(1).Day().At(startAt)
+	if err != nil {
+		t.Error(err)
+	}
 	dayJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+1, hour, minute, 0, 0, loc)
 	assertEqualTime(t, dayJob.nextRun, exp)
@@ -257,21 +267,40 @@ func TestWeekdayAt(t *testing.T) {
 
 	// Schedule job at next week day
 	var weekJob *Job
+	var err error
 	switch now.Weekday() {
 	case time.Monday:
-		weekJob = s.Every(1).Tuesday().At(startAt)
+		weekJob, err = s.Every(1).Tuesday().At(startAt)
+		if err != nil {
+			t.Error(err)
+		}
 	case time.Tuesday:
-		weekJob = s.Every(1).Wednesday().At(startAt)
+		weekJob, err = s.Every(1).Wednesday().At(startAt)
 	case time.Wednesday:
-		weekJob = s.Every(1).Thursday().At(startAt)
+		weekJob, err = s.Every(1).Thursday().At(startAt)
+		if err != nil {
+			t.Error(err)
+		}
 	case time.Thursday:
-		weekJob = s.Every(1).Friday().At(startAt)
+		weekJob, err = s.Every(1).Friday().At(startAt)
+		if err != nil {
+			t.Error(err)
+		}
 	case time.Friday:
-		weekJob = s.Every(1).Saturday().At(startAt)
+		weekJob, err = s.Every(1).Saturday().At(startAt)
+		if err != nil {
+			t.Error(err)
+		}
 	case time.Saturday:
-		weekJob = s.Every(1).Sunday().At(startAt)
+		weekJob, err = s.Every(1).Sunday().At(startAt)
+		if err != nil {
+			t.Error(err)
+		}
 	case time.Sunday:
-		weekJob = s.Every(1).Monday().At(startAt)
+		weekJob, err = s.Every(1).Monday().At(startAt)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 
 	// First run

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -114,8 +114,8 @@ func TestTaskAt(t *testing.T) {
 
 	// Schedule every day At
 	startAt := fmt.Sprintf("%02d:%02d", now.Hour(), now.Minute()+1)
-	dayJob, err := s.Every(1).Day().At(startAt)
-	if err != nil {
+	dayJob := s.Every(1).Day().At(startAt)
+	if err := dayJob.Err(); err != nil {
 		t.Error(err)
 	}
 
@@ -171,10 +171,11 @@ func TestDaily(t *testing.T) {
 	hour := now.Hour() - 2
 	minute := now.Minute()
 	startAt := fmt.Sprintf("%02d:%02d", hour, minute)
-	dayJob, err := s.Every(1).Day().At(startAt)
-	if err != nil {
+	dayJob = s.Every(1).Day().At(startAt)
+	if err := dayJob.Err(); err != nil {
 		t.Error(err)
 	}
+
 	dayJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+1, hour, minute, 0, 0, loc)
 	assertEqualTime(t, dayJob.nextRun, exp)
@@ -267,38 +268,40 @@ func TestWeekdayAt(t *testing.T) {
 
 	// Schedule job at next week day
 	var weekJob *Job
-	var err error
 	switch now.Weekday() {
 	case time.Monday:
-		weekJob, err = s.Every(1).Tuesday().At(startAt)
-		if err != nil {
+		weekJob = s.Every(1).Tuesday().At(startAt)
+		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Tuesday:
-		weekJob, err = s.Every(1).Wednesday().At(startAt)
+		weekJob = s.Every(1).Wednesday().At(startAt)
+		if err := weekJob.Err(); err != nil {
+			t.Error(err)
+		}
 	case time.Wednesday:
-		weekJob, err = s.Every(1).Thursday().At(startAt)
-		if err != nil {
+		weekJob = s.Every(1).Thursday().At(startAt)
+		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Thursday:
-		weekJob, err = s.Every(1).Friday().At(startAt)
-		if err != nil {
+		weekJob = s.Every(1).Friday().At(startAt)
+		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Friday:
-		weekJob, err = s.Every(1).Saturday().At(startAt)
-		if err != nil {
+		weekJob = s.Every(1).Saturday().At(startAt)
+		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Saturday:
-		weekJob, err = s.Every(1).Sunday().At(startAt)
-		if err != nil {
+		weekJob = s.Every(1).Sunday().At(startAt)
+		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Sunday:
-		weekJob, err = s.Every(1).Monday().At(startAt)
-		if err != nil {
+		weekJob = s.Every(1).Monday().At(startAt)
+		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	}

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -21,8 +21,8 @@ func assertEqualTime(name string, t *testing.T, actual, expected time.Time) {
 }
 
 func TestSecond(t *testing.T) {
-	defaultScheduler.Every(1).Second().Do(task)
-	defaultScheduler.Every(1).Second().Do(taskWithParams, 1, "hello")
+	defaultScheduler.Every(1, true).Second().Do(task)
+	defaultScheduler.Every(1, true).Second().Do(taskWithParams, 1, "hello")
 	stop := defaultScheduler.Start()
 	time.Sleep(5 * time.Second)
 	close(stop)
@@ -114,7 +114,7 @@ func TestTaskAt(t *testing.T) {
 
 	// Schedule every day At
 	startAt := fmt.Sprintf("%02d:%02d", now.Hour(), now.Minute()+1)
-	dayJob := s.Every(1).Day().At(startAt)
+	dayJob := s.Every(1, true).Day().At(startAt)
 	if err := dayJob.Err(); err != nil {
 		t.Error(err)
 	}
@@ -149,19 +149,19 @@ func TestDaily(t *testing.T) {
 	s := NewScheduler()
 
 	// schedule next run 1 day
-	dayJob := s.Every(1).Day()
+	dayJob := s.Every(1, true).Day()
 	dayJob.scheduleNextRun()
 	exp := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, loc)
 	assertEqualTime("1 day", t, dayJob.nextRun, exp)
 
 	// schedule next run 2 days
-	dayJob = s.Every(2).Days()
+	dayJob = s.Every(2, true).Days()
 	dayJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+2, 0, 0, 0, 0, loc)
 	assertEqualTime("2 days", t, dayJob.nextRun, exp)
 
 	// Job running longer than next schedule 1day 2 hours
-	dayJob = s.Every(1).Day()
+	dayJob = s.Every(1, true).Day()
 	dayJob.lastRun = time.Date(now.Year(), now.Month(), now.Day(), now.Hour()+2, 0, 0, 0, loc)
 	dayJob.scheduleNextRun()
 	exp = time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, loc)
@@ -171,7 +171,7 @@ func TestDaily(t *testing.T) {
 	hour := now.Hour() - 2
 	minute := now.Minute()
 	startAt := fmt.Sprintf("%02d:%02d", hour, minute)
-	dayJob = s.Every(1).Day().At(startAt)
+	dayJob = s.Every(1, true).Day().At(startAt)
 	if err := dayJob.Err(); err != nil {
 		t.Error(err)
 	}
@@ -191,19 +191,19 @@ func TestWeekdayAfterToday(t *testing.T) {
 	var weekJob *Job
 	switch now.Weekday() {
 	case time.Monday:
-		weekJob = s.Every(1).Tuesday()
+		weekJob = s.Every(1, true).Tuesday()
 	case time.Tuesday:
-		weekJob = s.Every(1).Wednesday()
+		weekJob = s.Every(1, true).Wednesday()
 	case time.Wednesday:
-		weekJob = s.Every(1).Thursday()
+		weekJob = s.Every(1, true).Thursday()
 	case time.Thursday:
-		weekJob = s.Every(1).Friday()
+		weekJob = s.Every(1, true).Friday()
 	case time.Friday:
-		weekJob = s.Every(1).Saturday()
+		weekJob = s.Every(1, true).Saturday()
 	case time.Saturday:
-		weekJob = s.Every(1).Sunday()
+		weekJob = s.Every(1, true).Sunday()
 	case time.Sunday:
-		weekJob = s.Every(1).Monday()
+		weekJob = s.Every(1, true).Monday()
 	}
 
 	// First run
@@ -229,19 +229,19 @@ func TestWeekdayBeforeToday(t *testing.T) {
 	var weekJob *Job
 	switch now.Weekday() {
 	case time.Monday:
-		weekJob = s.Every(1).Sunday()
+		weekJob = s.Every(1, true).Sunday()
 	case time.Tuesday:
-		weekJob = s.Every(1).Monday()
+		weekJob = s.Every(1, true).Monday()
 	case time.Wednesday:
-		weekJob = s.Every(1).Tuesday()
+		weekJob = s.Every(1, true).Tuesday()
 	case time.Thursday:
-		weekJob = s.Every(1).Wednesday()
+		weekJob = s.Every(1, true).Wednesday()
 	case time.Friday:
-		weekJob = s.Every(1).Thursday()
+		weekJob = s.Every(1, true).Thursday()
 	case time.Saturday:
-		weekJob = s.Every(1).Friday()
+		weekJob = s.Every(1, true).Friday()
 	case time.Sunday:
-		weekJob = s.Every(1).Saturday()
+		weekJob = s.Every(1, true).Saturday()
 	}
 
 	weekJob.scheduleNextRun()
@@ -270,37 +270,37 @@ func TestWeekdayAt(t *testing.T) {
 	var weekJob *Job
 	switch now.Weekday() {
 	case time.Monday:
-		weekJob = s.Every(1).Tuesday().At(startAt)
+		weekJob = s.Every(1, true).Tuesday().At(startAt)
 		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Tuesday:
-		weekJob = s.Every(1).Wednesday().At(startAt)
+		weekJob = s.Every(1, true).Wednesday().At(startAt)
 		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Wednesday:
-		weekJob = s.Every(1).Thursday().At(startAt)
+		weekJob = s.Every(1, true).Thursday().At(startAt)
 		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Thursday:
-		weekJob = s.Every(1).Friday().At(startAt)
+		weekJob = s.Every(1, true).Friday().At(startAt)
 		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Friday:
-		weekJob = s.Every(1).Saturday().At(startAt)
+		weekJob = s.Every(1, true).Saturday().At(startAt)
 		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Saturday:
-		weekJob = s.Every(1).Sunday().At(startAt)
+		weekJob = s.Every(1, true).Sunday().At(startAt)
 		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}
 	case time.Sunday:
-		weekJob = s.Every(1).Monday().At(startAt)
+		weekJob = s.Every(1, true).Monday().At(startAt)
 		if err := weekJob.Err(); err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
This PR was requested to be opened. It is a series of changes that make the code more production safe. In general it's not good practice to panic in source code that is meant to be imported. The user should be able to "catch" based on errors and not have to rely on `defer recover`